### PR TITLE
accept any byte-values in the status output

### DIFF
--- a/check_bacula_client
+++ b/check_bacula_client
@@ -56,7 +56,7 @@ def main(argv):
         if child.expect_list([re.compile(r'Terminated Jobs:'), re.compile(r'Error: Client resource .* does not exist.')]):
             raise RuntimeError('unknown client %s' % options.host)
         child.expect(r'\n\*')
-        r = re.compile(r'\s*(\d+)\s+(\S+)\s+(\S+)\s+(\d+\.\d+\s+[KMGTP]|0)\s+OK\s+(\S+\s+\S+)\s+%s' % re.escape(options.host))
+        r = re.compile(r'\s*(\d+)\s+(\S+)\s+(\S+)\s+(\d+\.\d+\s+[KMGTP]|\d+)\s+OK\s+(\S+\s+\S+)\s+%s' % re.escape(options.host))
         job_id = level = files = bytes = finished = None
         for line in child.before.splitlines():
             m = r.match(line)


### PR DESCRIPTION
otherwise lines like:
 51211  Incr          1       720   OK       24-Feb-14 01:06 foo-all
would be skipped, resulting in a "no terminated jobs" error.
